### PR TITLE
departmentsテーブルの作成

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,0 +1,2 @@
+class Department < ApplicationRecord
+end

--- a/db/migrate/20200712123322_create_departments.rb
+++ b/db/migrate/20200712123322_create_departments.rb
@@ -1,0 +1,7 @@
+class CreateDepartments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :departments do |t|
+      t.string :name, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,19 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_07_12_123322) do
+
+  create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+  end
+
+end


### PR DESCRIPTION
# what
社員(user)が属する部署を示す、departmentsテーブルを作成する。

# why
departmentsテーブルには外部キーを設定しない。
そのため、最初にdepartmentsテーブルを作成し、その後にアソシエーションを組みながら他のテーブルを作成する事とする。