### PR TITLE
design_dataテーブルの作成

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,3 +1,4 @@
 class Department < ApplicationRecord
   has_many :users
+  has_many :design_data
 end

--- a/app/models/design_datum.rb
+++ b/app/models/design_datum.rb
@@ -1,0 +1,6 @@
+class DesignDatum < ApplicationRecord
+  belongs_to :material
+  belongs_to :department
+  
+  validates :product_number, presence: true, uniqueness: true
+end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,2 +1,3 @@
 class Material < ApplicationRecord
+  has_many :design_data
 end

--- a/db/migrate/20200714181813_create_design_data.rb
+++ b/db/migrate/20200714181813_create_design_data.rb
@@ -1,0 +1,14 @@
+class CreateDesignData < ActiveRecord::Migration[5.2]
+  def change
+    create_table :design_data do |t|
+      t.string     :product_number, null: false
+      t.float      :length,         null: false
+      t.integer    :width,          null: false
+      t.references :client,         foreign_key: true
+      t.references :material,       foreign_key: true
+      t.timestamps
+    end
+
+    add_index :design_data, :product_number, unique: true, length: { is: 6 }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_14_160720) do
+ActiveRecord::Schema.define(version: 2020_07_14_181813) do
 
   create_table "clients", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "campany", null: false
@@ -18,6 +18,19 @@ ActiveRecord::Schema.define(version: 2020_07_14_160720) do
 
   create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
+  end
+
+  create_table "design_data", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "product_number", null: false
+    t.float "length", null: false
+    t.integer "width", null: false
+    t.bigint "client_id"
+    t.bigint "material_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_id"], name: "index_design_data_on_client_id"
+    t.index ["material_id"], name: "index_design_data_on_material_id"
+    t.index ["product_number"], name: "index_design_data_on_product_number", unique: true
   end
 
   create_table "materials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -40,5 +53,7 @@ ActiveRecord::Schema.define(version: 2020_07_14_160720) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "design_data", "clients"
+  add_foreign_key "design_data", "materials"
   add_foreign_key "users", "departments"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,16 +5,3 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-
-User.create(name: "テスト用　製造", employee_number: "123123", password: "test1231", department_id: 1)
-User.create(name: "テスト用　営業", employee_number: "123111", password: "test1111", department_id: 2)
-User.create(name: "セイゾウ　モノ太郎", employee_number: "010123", password: "manu0123", department_id: 1)
-User.create(name: "セイゾウ　する代", employee_number: "010456", password: "manu0456", department_id: 1)
-User.create(name: "エイギョウ　モノ次郎", employee_number: "020123", password: "sale0123", department_id: 2)
-User.create(name: "エイギョウ　うる代", employee_number: "020456", password: "sale0456", department_id: 2)
-Client.create(campany: "大日本工業")
-Client.create(campany: "カントウ産業")
-Client.create(campany: "NewTOKYO")
-Material.create(name: "Type-08", basis_weight: "0.8")
-Material.create(name: "Type-12", basis_weight: "1.2")
-Material.create(name: "Type-16", basis_weight: "1.6")


### PR DESCRIPTION
# what
設計情報を持つテーブルを作成する。
顧客名と材質は、それぞれclientsテーブルとmaterialsテーブルから引用する。
また、productsテーブル作成時に、本テーブルと一対一アソシエーションを設定する。

# why
productsテーブルには設計、製造、顧客評価の各情報を持ち、全てを一つのテーブルへ記述すると記述量が多くなりすぎるため各項目へ分割する。