### PR TITLE
production_dataの作成

### DIFF
--- a/app/models/production_datum.rb
+++ b/app/models/production_datum.rb
@@ -1,0 +1,3 @@
+class ProductionDatum < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   validates :employee_number, presence: true, uniqueness: true
 
   belongs_to :department
+  has_many   :production_data
 
   def email_required?
     false

--- a/db/migrate/20200714200832_create_production_data.rb
+++ b/db/migrate/20200714200832_create_production_data.rb
@@ -1,0 +1,10 @@
+class CreateProductionData < ActiveRecord::Migration[5.2]
+  def change
+    create_table :production_data do |t|
+      t.text       :comment, null: false
+      t.string     :image
+      t.references :user,    foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_14_181813) do
+ActiveRecord::Schema.define(version: 2020_07_14_200832) do
 
   create_table "clients", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "campany", null: false
@@ -38,6 +38,15 @@ ActiveRecord::Schema.define(version: 2020_07_14_181813) do
     t.float "basis_weight", null: false
   end
 
+  create_table "production_data", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "comment", null: false
+    t.string "image"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_production_data_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "employee_number", null: false
@@ -55,5 +64,6 @@ ActiveRecord::Schema.define(version: 2020_07_14_181813) do
 
   add_foreign_key "design_data", "clients"
   add_foreign_key "design_data", "materials"
+  add_foreign_key "production_data", "users"
   add_foreign_key "users", "departments"
 end


### PR DESCRIPTION
# what
製造工程の情報を持つテーブルを作成する。
担当者名は、userテーブルから引用する。
また、productsテーブル作成時に、本テーブルと一対一アソシエーションを設定する。

# why
productsテーブルは設計、製造、顧客評価の各情報を持ち、全てを一つのテーブルへ記述すると記述量が多くなりすぎるため各項目へ分割する。