### PR TITLE
evaluation_dataテーブルの作成

### DIFF
--- a/app/models/evaluation_datum.rb
+++ b/app/models/evaluation_datum.rb
@@ -1,0 +1,3 @@
+class EvaluationDatum < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   belongs_to :department
   has_many   :production_data
   has_many   :inspection_data
+  has_many   :evaluation_data
 
   def email_required?
     false

--- a/db/migrate/20200714205149_create_evaluation_data.rb
+++ b/db/migrate/20200714205149_create_evaluation_data.rb
@@ -1,0 +1,10 @@
+class CreateEvaluationData < ActiveRecord::Migration[5.2]
+  def change
+    create_table :evaluation_data do |t|
+      t.text       :comment, null: false
+      t.string     :image
+      t.references :user,    foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_14_203558) do
+ActiveRecord::Schema.define(version: 2020_07_14_205149) do
 
   create_table "clients", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "campany", null: false
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2020_07_14_203558) do
     t.index ["client_id"], name: "index_design_data_on_client_id"
     t.index ["material_id"], name: "index_design_data_on_material_id"
     t.index ["product_number"], name: "index_design_data_on_product_number", unique: true
+  end
+
+  create_table "evaluation_data", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "comment", null: false
+    t.string "image"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_evaluation_data_on_user_id"
   end
 
   create_table "inspection_data", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -76,6 +85,7 @@ ActiveRecord::Schema.define(version: 2020_07_14_203558) do
 
   add_foreign_key "design_data", "clients"
   add_foreign_key "design_data", "materials"
+  add_foreign_key "evaluation_data", "users"
   add_foreign_key "inspection_data", "users"
   add_foreign_key "production_data", "users"
   add_foreign_key "users", "departments"


### PR DESCRIPTION
# what
顧客評価の情報を持つテーブルを作成する。
担当者名は、userテーブルから引用する。
また、productsテーブル作成時に、本テーブルと一対一アソシエーションを設定する。

# why
productsテーブルは設計、製造（製造・検査）、顧客評価の各情報を持ち、全てを一つのテーブルへ記述すると記述量が多くなりすぎるため各項目へ分割する。